### PR TITLE
Fix longitude and latitude calculations, and ROS publishing

### DIFF
--- a/include/wit_node/command.hpp
+++ b/include/wit_node/command.hpp
@@ -71,7 +71,7 @@ class Command : public packet_handler::payloadBase {
           location(2047),
           read_start(0x38),
           read_length(15) {
-      for (int i = 1; i < 13; i++) {
+      for (int i = 0; i < 12; i++) {
         sycn_location[i] = 2047;
       }
     }

--- a/launch/wit.launch
+++ b/launch/wit.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="port"                  default = "/dev/ttyUSB0" />
-  <node pkg="nodelet" type="nodelet" name="wit_nodelet_manager" args="manager"/>
-  <node pkg="nodelet" type="nodelet" name="wit" args="load wit_node/WitNodelet wit_nodelet_manager" >
+  <node pkg="nodelet" type="nodelet" output="screen" name="wit_nodelet_manager" args="manager"/>
+  <node pkg="nodelet" type="nodelet" output="screen" name="wit" args="load wit_node/WitNodelet wit_nodelet_manager" >
     <param name="port" value="$(arg port)" />
   </node>
 </launch>

--- a/src/driver/data.cpp
+++ b/src/driver/data.cpp
@@ -86,9 +86,23 @@ bool Data::desGyro(ecl::PushAndPop<unsigned char> &byteStream) {
     return false;
   }
 }
+
+// Given the measurement as a float (incorrectly), convert it to decimal degrees.
+static float fixBits(float measurement, const char *name) {
+  static const float seven_zeros = 10000000;
+
+  int int_measurement = reinterpret_cast<int&>(measurement);
+  float degrees = int_measurement / seven_zeros;
+  float minutes_and_seconds = (int_measurement % (int)seven_zeros)/seven_zeros;
+  return degrees + minutes_and_seconds*100/60;
+}
+
 bool Data::desLola(ecl::PushAndPop<unsigned char> &byteStream) {
   buildVariable(imugps_.longtitude, byteStream);
   buildVariable(imugps_.latitude, byteStream);
+
+  imugps_.latitude = fixBits(imugps_.latitude, "latitude");
+  imugps_.longtitude = fixBits(imugps_.longtitude, "longitude");
   if (byteStream.size() == 0) {
     //    std::cout << imugps_.pressure << std::endl;
     return true;

--- a/src/ros/wit_ros.cpp
+++ b/src/ros/wit_ros.cpp
@@ -66,6 +66,7 @@ bool WitRos::update() {
         "Wit : arm serial port is not connetced, please connect the arm.");
     return false;
   }
+  processStreamData();
   return true;
 }
 


### PR DESCRIPTION
Previously, the data was incorrectly being published as a `float`, when
it was in fact the integer value according to the layout in the data
sheet. The fix was to cast it back to an integer, then convert it
properly to decimal degrees.

Additionally, `wit_ros` previously didn't publish any data to the ROS streams, only advertise that they were available. This changes it to publish the data.

Fixes https://github.com/yowlings/wit_node/issues/3.